### PR TITLE
Port HTML templates into Go HTML components.

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,0 +1,97 @@
+// +build ignore
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/shurcooL/notifications/fs"
+	"github.com/shurcooL/notificationsapp"
+	"github.com/shurcooL/users"
+	"golang.org/x/net/webdav"
+)
+
+var (
+	httpFlag = flag.String("http", ":8080", "Listen for HTTP connections on this address.")
+)
+
+func main() {
+	err := run()
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func run() error {
+	flag.Parse()
+
+	users := mockUsers{}
+	service := fs.NewService(webdav.Dir("/Users/Dmitri/Dropbox/Work/2013/GoLand/src/github.com/shurcooL/home/http/testdata/notifications"), users)
+
+	opt := notificationsapp.Options{
+		// TODO: Update and unify octicons.css.
+		//       But be mindful of https://github.com/shurcooL/notifications/blob/c38c34c46358723f7f329fa80f9a4ae105b60985/notifications.go#L39.
+		HeadPre: `<title>Notifications</title>
+<link href="//cdnjs.cloudflare.com/ajax/libs/octicons/3.1.0/octicons.css" media="all" rel="stylesheet" type="text/css" />
+<style type="text/css">
+	body {
+		margin: 20px;
+	}
+	body, table {
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-size: 14px;
+		line-height: initial;
+		color: #373a3c;
+	}
+</style>`,
+	}
+	opt.BodyPre = `<div style="max-width: 800px; margin: 0 auto 100px auto;">`
+	notificationsApp := notificationsapp.New(service, users, opt)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		req = req.WithContext(context.WithValue(req.Context(), notificationsapp.BaseURIContextKey, ".")) // TODO: Confirm "." vs "/" vs "".
+		notificationsApp.ServeHTTP(w, req)
+	})
+
+	log.Println("Started.")
+
+	err := http.ListenAndServe(*httpFlag, nil)
+	return err
+}
+
+type mockUsers struct {
+	users.Service
+}
+
+func (mockUsers) Get(_ context.Context, user users.UserSpec) (users.User, error) {
+	switch {
+	case user == users.UserSpec{ID: 1, Domain: "example.org"}:
+		return users.User{
+			UserSpec: user,
+			Login:    "gopher",
+			Name:     "Sample Gopher",
+			Email:    "gopher@example.org",
+		}, nil
+	default:
+		return users.User{}, fmt.Errorf("user %v not found", user)
+	}
+}
+
+func (mockUsers) GetAuthenticatedSpec(_ context.Context) (users.UserSpec, error) {
+	return users.UserSpec{ID: 1, Domain: "example.org"}, nil
+}
+
+func (m mockUsers) GetAuthenticated(ctx context.Context) (users.User, error) {
+	userSpec, err := m.GetAuthenticatedSpec(ctx)
+	if err != nil {
+		return users.User{}, err
+	}
+	if userSpec.ID == 0 {
+		return users.User{}, nil
+	}
+	return m.Get(ctx, userSpec)
+}

--- a/app.go
+++ b/app.go
@@ -1,18 +1,19 @@
 // +build ignore
 
+// An app that serves mock notifications for development and testing.
 package main
 
 import (
 	"context"
 	"flag"
-	"fmt"
+	"html/template"
 	"log"
 	"net/http"
+	"time"
 
-	"github.com/shurcooL/notifications/fs"
+	"github.com/shurcooL/notifications"
 	"github.com/shurcooL/notificationsapp"
 	"github.com/shurcooL/users"
-	"golang.org/x/net/webdav"
 )
 
 var (
@@ -29,14 +30,10 @@ func main() {
 func run() error {
 	flag.Parse()
 
-	users := mockUsers{}
-	service := fs.NewService(webdav.Dir("/Users/Dmitri/Dropbox/Work/2013/GoLand/src/github.com/shurcooL/home/http/testdata/notifications"), users)
+	service := mockNotifications{}
 
 	opt := notificationsapp.Options{
-		// TODO: Update and unify octicons.css.
-		//       But be mindful of https://github.com/shurcooL/notifications/blob/c38c34c46358723f7f329fa80f9a4ae105b60985/notifications.go#L39.
 		HeadPre: `<title>Notifications</title>
-<link href="//cdnjs.cloudflare.com/ajax/libs/octicons/3.1.0/octicons.css" media="all" rel="stylesheet" type="text/css" />
 <style type="text/css">
 	body {
 		margin: 20px;
@@ -50,7 +47,7 @@ func run() error {
 </style>`,
 	}
 	opt.BodyPre = `<div style="max-width: 800px; margin: 0 auto 100px auto;">`
-	notificationsApp := notificationsapp.New(service, users, opt)
+	notificationsApp := notificationsapp.New(service, opt)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		req = req.WithContext(context.WithValue(req.Context(), notificationsapp.BaseURIContextKey, ".")) // TODO: Confirm "." vs "/" vs "".
@@ -63,35 +60,334 @@ func run() error {
 	return err
 }
 
-type mockUsers struct {
-	users.Service
+type mockNotifications struct {
+	notifications.Service
 }
 
-func (mockUsers) Get(_ context.Context, user users.UserSpec) (users.User, error) {
-	switch {
-	case user == users.UserSpec{ID: 1, Domain: "example.org"}:
-		return users.User{
-			UserSpec: user,
-			Login:    "gopher",
-			Name:     "Sample Gopher",
-			Email:    "gopher@example.org",
-		}, nil
-	default:
-		return users.User{}, fmt.Errorf("user %v not found", user)
-	}
-}
+func (mockNotifications) List(ctx context.Context, opt notifications.ListOptions) (notifications.Notifications, error) {
+	passed := time.Since(time.Date(1, 1, 1, 0, 0, 63621777703, 945428426, time.UTC))
 
-func (mockUsers) GetAuthenticatedSpec(_ context.Context) (users.UserSpec, error) {
-	return users.UserSpec{ID: 1, Domain: "example.org"}, nil
-}
-
-func (m mockUsers) GetAuthenticated(ctx context.Context) (users.User, error) {
-	userSpec, err := m.GetAuthenticatedSpec(ctx)
-	if err != nil {
-		return users.User{}, err
-	}
-	if userSpec.ID == 0 {
-		return users.User{}, nil
-	}
-	return m.Get(ctx, userSpec)
+	ns := (notifications.Notifications)(notifications.Notifications{
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("PullRequest"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/bradleyfalzon/gopherci"),
+			}),
+			ThreadID: (uint64)(60),
+			RepoURL:  (template.URL)("https://github.com/bradleyfalzon/gopherci"),
+			Title:    (string)("Support GitHub PushEvent"),
+			Icon:     (notifications.OcticonID)("git-pull-request"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(108),
+				G: (uint8)(198),
+				B: (uint8)(68),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(2354108),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("coveralls"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/2354108?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/coveralls"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621776801, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/bradleyfalzon/gopherci/pull/60#comment-277416148"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("PullRequest"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/ryanuber/go-glob"),
+			}),
+			ThreadID: (uint64)(5),
+			RepoURL:  (template.URL)("https://github.com/ryanuber/go-glob"),
+			Title:    (string)("Add GlobI for case-insensitive globbing"),
+			Icon:     (notifications.OcticonID)("git-pull-request"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(108),
+				G: (uint8)(198),
+				B: (uint8)(68),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(3022496),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("blockloop"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/3022496?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/blockloop"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621776446, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/ryanuber/go-glob/pull/5#comment-277415841"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("Issue"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/nsf/gocode"),
+			}),
+			ThreadID: (uint64)(419),
+			RepoURL:  (template.URL)("https://github.com/nsf/gocode"),
+			Title:    (string)("panic: unknown export format version 4"),
+			Icon:     (notifications.OcticonID)("issue-closed"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(189),
+				G: (uint8)(44),
+				B: (uint8)(0),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(45629),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("davidlazar"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/45629?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/davidlazar"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621775009, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/nsf/gocode/issues/419#comment-277414645"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("Issue"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/robpike/ivy"),
+			}),
+			ThreadID: (uint64)(31),
+			RepoURL:  (template.URL)("https://github.com/robpike/ivy"),
+			Title:    (string)("loop termination condition seems wrong"),
+			Icon:     (notifications.OcticonID)("issue-opened"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(108),
+				G: (uint8)(198),
+				B: (uint8)(68),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(4324516),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("robpike"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/4324516?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/robpike"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621763429, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/robpike/ivy/issues/31#comment-277396571"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("PullRequest"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/nsf/gocode"),
+			}),
+			ThreadID: (uint64)(417),
+			RepoURL:  (template.URL)("https://github.com/nsf/gocode"),
+			Title:    (string)("[WIP] package_bin: support type alias"),
+			Icon:     (notifications.OcticonID)("git-pull-request"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(108),
+				G: (uint8)(198),
+				B: (uint8)(68),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(12567),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("nsf"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/12567?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/nsf"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621764131, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/nsf/gocode/pull/417#comment-277398182"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("PullRequest"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/google/go-github"),
+			}),
+			ThreadID: (uint64)(538),
+			RepoURL:  (template.URL)("https://github.com/google/go-github"),
+			Title:    (string)("Added listing outside collaborators for an organization"),
+			Icon:     (notifications.OcticonID)("git-pull-request"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(108),
+				G: (uint8)(198),
+				B: (uint8)(68),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(6598971),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("gmlewis"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/6598971?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/gmlewis"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621757401, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/google/go-github/pull/538#comment-277378904"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("Issue"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/nsf/gocode"),
+			}),
+			ThreadID: (uint64)(396),
+			RepoURL:  (template.URL)("https://github.com/nsf/gocode"),
+			Title:    (string)("PANIC!!! "),
+			Icon:     (notifications.OcticonID)("issue-opened"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(108),
+				G: (uint8)(198),
+				B: (uint8)(68),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(8503),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("samuel"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/8503?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/samuel"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621747822, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/nsf/gocode/issues/396#comment-277343192"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("Issue"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/primer/octicons"),
+			}),
+			ThreadID: (uint64)(154),
+			RepoURL:  (template.URL)("https://github.com/primer/octicons"),
+			Title:    (string)("Please add more variants for refresh icon."),
+			Icon:     (notifications.OcticonID)("issue-closed"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(189),
+				G: (uint8)(44),
+				B: (uint8)(0),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(11073943),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("souravbadami"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/11073943?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/souravbadami"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621746110, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/primer/octicons/issues/154"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("Issue"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/primer/octicons"),
+			}),
+			ThreadID: (uint64)(78),
+			RepoURL:  (template.URL)("https://github.com/primer/octicons"),
+			Title:    (string)("Add pause icon"),
+			Icon:     (notifications.OcticonID)("issue-closed"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(189),
+				G: (uint8)(44),
+				B: (uint8)(0),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(6053067),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("Odonno"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/6053067?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/Odonno"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621746061, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/primer/octicons/issues/78"),
+		}),
+		(notifications.Notification)(notifications.Notification{
+			AppID: (string)("Issue"),
+			RepoSpec: (notifications.RepoSpec)(notifications.RepoSpec{
+				URI: (string)("github.com/neelance/graphql-go"),
+			}),
+			ThreadID: (uint64)(53),
+			RepoURL:  (template.URL)("https://github.com/neelance/graphql-go"),
+			Title:    (string)("Opentracing not tracing graphql traces"),
+			Icon:     (notifications.OcticonID)("issue-opened"),
+			Color: (notifications.RGB)(notifications.RGB{
+				R: (uint8)(108),
+				G: (uint8)(198),
+				B: (uint8)(68),
+			}),
+			Actor: (users.User)(users.User{
+				UserSpec: (users.UserSpec)(users.UserSpec{
+					ID:     (uint64)(1966521),
+					Domain: (string)("github.com"),
+				}),
+				Elsewhere: ([]users.UserSpec)(nil),
+				Login:     (string)("bsr203"),
+				Name:      (string)(""),
+				Email:     (string)(""),
+				AvatarURL: (template.URL)("https://avatars.githubusercontent.com/u/1966521?s=36&v=3"),
+				HTMLURL:   (template.URL)("https://github.com/bsr203"),
+				CreatedAt: (time.Time)(time.Time{}),
+				UpdatedAt: (time.Time)(time.Time{}),
+				SiteAdmin: (bool)(false),
+			}),
+			UpdatedAt: (time.Time)(time.Date(1, 1, 1, 0, 0, 63621743050, 0, time.UTC).Add(passed)),
+			HTMLURL:   (template.URL)("https://github.com/neelance/graphql-go/issues/53#comment-277322972"),
+		}),
+	})
+	return ns, nil
 }

--- a/assets/_data/head.html.tmpl
+++ b/assets/_data/head.html.tmpl
@@ -1,9 +1,0 @@
-{{define "scriptless-head"}}
-	{{.HeadPre}}
-	<link href="{{.BaseURI}}/assets/style.css" rel="stylesheet" type="text/css" />
-{{end}}
-
-{{define "head"}}
-	{{template "scriptless-head" .}}
-	<script src="{{.BaseURI}}/assets/script/script.js" type="text/javascript"></script>
-{{end}}

--- a/assets/_data/notifications.html.tmpl
+++ b/assets/_data/notifications.html.tmpl
@@ -7,6 +7,3 @@
 	<body>
 		{{.BodyPre}}
 		{{.BodyTop}}
-		{{render .AllNotifications}}
-	</body>
-</html>

--- a/assets/_data/notifications.html.tmpl
+++ b/assets/_data/notifications.html.tmpl
@@ -7,14 +7,6 @@
 	<body>
 		{{.BodyPre}}
 		{{.BodyTop}}
-		{{template "notifications" .RepoNotifications}}
+		{{render .AllNotifications}}
 	</body>
 </html>
-
-{{define "notifications"}}
-{{with .}}{{range .}}
-	{{render .}}
-{{end}}{{else}}
-	<div style="text-align: center; margin-top: 80px; margin-bottom: 80px;">No new notifications.</div>
-{{end}}
-{{end}}

--- a/assets/_data/notifications.html.tmpl
+++ b/assets/_data/notifications.html.tmpl
@@ -17,23 +17,7 @@
 			<span class="right-icon hide-when-read"><a href="javascript:" onclick="MarkAllRead(this, {{.Repo.URI | json}});" title="Mark all {{base .Repo.URI}} notifications as read"><span class="octicon octicon-check"></span></a></span>
 		</div>
 		{{range .Notifications}}
-			<div class="list-entry-body multilist-entry mark-as-read">
-				<span class="content">
-					<table style="width: 100%;">
-					<tr>
-					<td class="notification" style="width: 70%;">
-						<span class="octicon octicon-{{.Icon}} fade-when-read" style="color: {{.Color.HexString}};"></span>
-						<a class="black gray-when-read" onclick="MarkRead(this, {{`` | json}}, {{`` | json}}, 0);" href="{{.HTMLURL}}">{{.Title}}</a>
-					</td>
-					<td>
-						{{if .Actor.AvatarURL}}<img class="avatar fade-when-read" title="@{{.Actor.Login}}" src="{{.Actor.AvatarURL}}">{{end -}}
-						<span class="tiny gray-when-read">{{render .UpdatedAtComponent}}</span>
-					</td>
-					</tr>
-					</table>
-				</span>
-				<span class="right-icon hide-when-read"><a href="javascript:" onclick="MarkRead(this, {{.AppID | json}}, {{.RepoSpec.URI | json}}, {{.ThreadID}});" title="Mark as read"><span class="octicon octicon-check"></span></a></span>
-			</div>
+			{{render .}}
 		{{end}}
 	</div>
 {{end}}{{else}}

--- a/assets/_data/notifications.html.tmpl
+++ b/assets/_data/notifications.html.tmpl
@@ -1,9 +1,0 @@
-<html>
-	<head>
-		{{.HeadPre}}
-		<link href="{{.BaseURI}}/assets/style.css" rel="stylesheet" type="text/css" />
-		<script src="{{.BaseURI}}/assets/script/script.js" type="text/javascript"></script>
-	</head>
-	<body>
-		{{.BodyPre}}
-		{{.BodyTop}}

--- a/assets/_data/notifications.html.tmpl
+++ b/assets/_data/notifications.html.tmpl
@@ -11,15 +11,7 @@
 
 {{define "notifications"}}
 {{with .}}{{range .}}
-	<div class="list-entry list-entry-border mark-as-read">
-		<div class="list-entry-header">
-			<span class="content"><a class="black" href="{{.RepoURL}}"><strong>{{.Repo.URI}}</strong></a></span>
-			<span class="right-icon hide-when-read"><a href="javascript:" onclick="MarkAllRead(this, {{.Repo.URI | json}});" title="Mark all {{base .Repo.URI}} notifications as read"><span class="octicon octicon-check"></span></a></span>
-		</div>
-		{{range .Notifications}}
-			{{render .}}
-		{{end}}
-	</div>
+	{{render .}}
 {{end}}{{else}}
 	<div style="text-align: center; margin-top: 80px; margin-bottom: 80px;">No new notifications.</div>
 {{end}}

--- a/assets/_data/notifications.html.tmpl
+++ b/assets/_data/notifications.html.tmpl
@@ -27,7 +27,7 @@
 					</td>
 					<td>
 						{{if .Actor.AvatarURL}}<img class="avatar fade-when-read" title="@{{.Actor.Login}}" src="{{.Actor.AvatarURL}}">{{end -}}
-						<span class="tiny gray-when-read">{{template "time" .UpdatedAt}}</span>
+						<span class="tiny gray-when-read">{{render .UpdatedAtComponent}}</span>
 					</td>
 					</tr>
 					</table>

--- a/assets/_data/notifications.html.tmpl
+++ b/assets/_data/notifications.html.tmpl
@@ -1,6 +1,8 @@
 <html>
 	<head>
-		{{template "head" .}}
+		{{.HeadPre}}
+		<link href="{{.BaseURI}}/assets/style.css" rel="stylesheet" type="text/css" />
+		<script src="{{.BaseURI}}/assets/script/script.js" type="text/javascript"></script>
 	</head>
 	<body>
 		{{.BodyPre}}

--- a/assets/_data/style.css
+++ b/assets/_data/style.css
@@ -33,10 +33,6 @@ div.multilist-entry:not(:nth-child(0n+2)) {
 	border-top-width: 1px;
 }
 
-.notification .octicon {
-	margin-right: 6px;
-}
-
 .read .gray-when-read {
 	color: #888 !important;
 }

--- a/assets/_data/util.html.tmpl
+++ b/assets/_data/util.html.tmpl
@@ -1,1 +1,0 @@
-{{define "time"}}<abbr title="{{.Format "Jan _2, 2006, 3:04 PM MST"}}">{{reltime .}}</abbr>{{end}}

--- a/component/component.go
+++ b/component/component.go
@@ -1,14 +1,227 @@
 package component
 
 import (
+	"context"
+	"fmt"
+	"html/template"
+	"path"
+	"sort"
 	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/shurcooL/htmlg"
+	"github.com/shurcooL/notifications"
+	"github.com/shurcooL/octiconssvg"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 )
 
+// TODO: This doesn't belong here, does it? Figure out where to best move it.
+func FetchRepoNotifications(ctx context.Context, service notifications.Service) ([]RepoNotifications, error) {
+	ns, err := service.List(ctx, notifications.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	rnm := make(map[notifications.RepoSpec]*RepoNotifications)
+	for _, n := range ns {
+		var r notifications.RepoSpec = n.RepoSpec
+		switch rnp := rnm[r]; rnp {
+		case nil:
+			rn := RepoNotifications{
+				Repo:          r,
+				RepoURL:       n.RepoURL,
+				Notifications: []Notification{{n}},
+				updatedAt:     n.UpdatedAt,
+			}
+			rnm[r] = &rn
+		default:
+			if rnp.updatedAt.Before(n.UpdatedAt) {
+				rnp.updatedAt = n.UpdatedAt
+			}
+			rnp.Notifications = append(rnp.Notifications, Notification{n})
+		}
+	}
+
+	var rns []RepoNotifications
+	for _, rnp := range rnm {
+		sort.Sort(nByUpdatedAt(rnp.Notifications))
+		rns = append(rns, *rnp)
+	}
+	sort.Sort(rnByUpdatedAt(rns))
+
+	return rns, nil
+}
+
+// rnByUpdatedAt implements sort.Interface.
+type rnByUpdatedAt []RepoNotifications
+
+func (s rnByUpdatedAt) Len() int           { return len(s) }
+func (s rnByUpdatedAt) Less(i, j int) bool { return !s[i].updatedAt.Before(s[j].updatedAt) }
+func (s rnByUpdatedAt) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// nByUpdatedAt implements sort.Interface.
+type nByUpdatedAt []Notification
+
+func (s nByUpdatedAt) Len() int           { return len(s) }
+func (s nByUpdatedAt) Less(i, j int) bool { return !s[i].UpdatedAt.Before(s[j].UpdatedAt) }
+func (s nByUpdatedAt) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// ---
+
+type AllNotifications struct {
+	All []RepoNotifications
+}
+
+func (a AllNotifications) Render() []*html.Node {
+	// TODO: Make this much nicer.
+	/*
+		{{if .}}{{range .}}
+			{{render .}}
+		{{end}}{{else}}
+			<div style="text-align: center; margin-top: 80px; margin-bottom: 80px;">No new notifications.</div>
+		{{end}}
+	*/
+	if len(a.All) == 0 {
+		div := &html.Node{
+			Type: html.ElementNode, Data: atom.Div.String(),
+			Attr: []html.Attribute{
+				{Key: atom.Style.String(), Val: "text-align: center; margin-top: 80px; margin-bottom: 80px;"},
+			},
+			FirstChild: htmlg.Text("No new notifications."),
+		}
+		return []*html.Node{div}
+	}
+	var ns []*html.Node
+	for _, repoNotifications := range a.All {
+		ns = append(ns, repoNotifications.Render()...)
+	}
+	return ns
+}
+
+type RepoNotifications struct {
+	Repo          notifications.RepoSpec
+	RepoURL       template.URL
+	Notifications []Notification
+
+	updatedAt time.Time // Most recent notification.
+}
+
+func (r RepoNotifications) Render() []*html.Node {
+	// TODO: Make this much nicer.
+	/*
+		<div class="list-entry list-entry-border mark-as-read">
+			<div class="list-entry-header">
+				<span class="content"><a class="black" href="{{.RepoURL}}"><strong>{{.Repo.URI}}</strong></a></span>
+				<span class="right-icon hide-when-read"><a href="javascript:" onclick="MarkAllRead(this, {{.Repo.URI | json}});" title="Mark all {{base .Repo.URI}} notifications as read"><span class="octicon octicon-check"></span></a></span>
+			</div>
+			{{range .Notifications}}
+				{{render .}}
+			{{end}}
+		</div>
+	*/
+	var ns []*html.Node
+	ns = append(ns, htmlg.DivClass("list-entry-header",
+		htmlg.SpanClass("content",
+			&html.Node{
+				Type: html.ElementNode, Data: atom.A.String(),
+				Attr: []html.Attribute{
+					{Key: atom.Class.String(), Val: "black"},
+					{Key: atom.Href.String(), Val: string(r.RepoURL)},
+				},
+				FirstChild: htmlg.Strong(r.Repo.URI),
+			},
+		),
+		htmlg.SpanClass("right-icon hide-when-read",
+			&html.Node{
+				Type: html.ElementNode, Data: atom.A.String(),
+				Attr: []html.Attribute{
+					{Key: atom.Href.String(), Val: "javascript:"},
+					{Key: atom.Onclick.String(), Val: fmt.Sprintf("MarkAllRead(this, %q);", r.Repo.URI)},
+					{Key: atom.Title.String(), Val: fmt.Sprintf("Mark all %s notifications as read", path.Base(r.Repo.URI))},
+				},
+				FirstChild: octiconssvg.Check(),
+			},
+		),
+	))
+	for _, notification := range r.Notifications {
+		ns = append(ns, notification.Render()...)
+	}
+	div := htmlg.DivClass("list-entry list-entry-border mark-as-read", ns...)
+	return []*html.Node{div}
+}
+
+// Notification for display purposes.
+type Notification struct {
+	notifications.Notification
+}
+
+func (n Notification) Render() []*html.Node {
+	// TODO: Make this much nicer.
+	/*
+		<div class="list-entry-body multilist-entry mark-as-read">
+			<span class="content">
+				<table style="width: 100%;">
+				<tr>
+				<td class="notification" style="width: 70%;">
+					<span class="fade-when-read" style="color: {{.Color.HexString}}; margin-right: 6px; vertical-align: top;"><octiconssvg.Icon(.Icon)></span>
+					<a class="black gray-when-read" onclick="MarkRead(this, {{`` | json}}, {{`` | json}}, 0);" href="{{.HTMLURL}}">{{.Title}}</a>
+				</td>
+				<td>
+					{{if .Actor.AvatarURL}}<img class="avatar fade-when-read" title="@{{.Actor.Login}}" src="{{.Actor.AvatarURL}}">{{end -}}
+					<span class="tiny gray-when-read">Time{.UpdatedAt}</span>
+				</td>
+				</tr>
+				</table>
+			</span>
+			<span class="right-icon hide-when-read"><a href="javascript:" onclick="MarkRead(this, {{.AppID | json}}, {{.RepoSpec.URI | json}}, {{.ThreadID}});" title="Mark as read"><octiconssvg.Check()>"</a></span>
+		</div>
+	*/
+	icon := htmlg.SpanClass("fade-when-read", octiconssvg.Icon(string(n.Icon)))
+	icon.Attr = append(icon.Attr, html.Attribute{
+		Key: atom.Style.String(), Val: fmt.Sprintf("color: %s; margin-right: 6px; vertical-align: top;", n.Color.HexString()),
+	})
+	td1 := htmlg.TD(
+		icon,
+		&html.Node{
+			Type: html.ElementNode, Data: atom.A.String(),
+			Attr: []html.Attribute{
+				{Key: atom.Class.String(), Val: "black gray-when-read"},
+				{Key: atom.Onclick.String(), Val: `MarkRead(this, "", "", 0);`},
+				{Key: atom.Href.String(), Val: string(n.HTMLURL)},
+			},
+			FirstChild: htmlg.Text(n.Title),
+		},
+	)
+	td1.Attr = append(td1.Attr, html.Attribute{Key: atom.Style.String(), Val: "width: 70%;"})
+	td2 := htmlg.TD(
+		htmlg.SpanClass("tiny gray-when-read", Time{n.UpdatedAt}.Render()...),
+	)
+	tr := htmlg.TR(td1, td2)
+	table := &html.Node{
+		Type: html.ElementNode, Data: atom.Table.String(),
+		Attr: []html.Attribute{
+			{Key: atom.Style.String(), Val: "width: 100%;"},
+		},
+		FirstChild: tr,
+	}
+	span1 := htmlg.SpanClass("content", table)
+	span2 := htmlg.SpanClass("right-icon hide-when-read",
+		&html.Node{
+			Type: html.ElementNode, Data: atom.A.String(),
+			Attr: []html.Attribute{
+				{Key: atom.Href.String(), Val: "javascript:"},
+				{Key: atom.Onclick.String(), Val: fmt.Sprintf("MarkRead(this, %q, %q, %v);", n.AppID, n.RepoSpec.URI, n.ThreadID)},
+				{Key: atom.Title.String(), Val: "Mark as read"},
+			},
+			FirstChild: octiconssvg.Check(),
+		},
+	)
+	div := htmlg.DivClass("list-entry-body multilist-entry mark-as-read", span1, span2)
+	return []*html.Node{div}
+}
+
+// Time component.
 type Time struct {
 	Time time.Time
 }

--- a/component/component.go
+++ b/component/component.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -131,7 +132,7 @@ func (r RepoNotifications) Render() []*html.Node {
 				Type: html.ElementNode, Data: atom.A.String(),
 				Attr: []html.Attribute{
 					{Key: atom.Href.String(), Val: "javascript:"},
-					{Key: atom.Onclick.String(), Val: fmt.Sprintf("MarkAllRead(this, %q);", r.Repo.URI)},
+					{Key: atom.Onclick.String(), Val: fmt.Sprintf("MarkAllRead(this, %q);", strconv.Quote(r.Repo.URI))},
 					{Key: atom.Title.String(), Val: fmt.Sprintf("Mark all %s notifications as read", path.Base(r.Repo.URI))},
 				},
 				FirstChild: octiconssvg.Check(),
@@ -181,7 +182,7 @@ func (n Notification) Render() []*html.Node {
 			Type: html.ElementNode, Data: atom.A.String(),
 			Attr: []html.Attribute{
 				{Key: atom.Class.String(), Val: "black gray-when-read"},
-				{Key: atom.Onclick.String(), Val: `MarkRead(this, "", "", 0);`},
+				{Key: atom.Onclick.String(), Val: `MarkRead(this, '""', '""', 0);`},
 				{Key: atom.Href.String(), Val: string(n.HTMLURL)},
 			},
 			FirstChild: htmlg.Text(n.Title),
@@ -214,7 +215,7 @@ func (n Notification) Render() []*html.Node {
 			Type: html.ElementNode, Data: atom.A.String(),
 			Attr: []html.Attribute{
 				{Key: atom.Href.String(), Val: "javascript:"},
-				{Key: atom.Onclick.String(), Val: fmt.Sprintf("MarkRead(this, %q, %q, %v);", n.AppID, n.RepoSpec.URI, n.ThreadID)},
+				{Key: atom.Onclick.String(), Val: fmt.Sprintf("MarkRead(this, %q, %q, %v);", strconv.Quote(n.AppID), strconv.Quote(n.RepoSpec.URI), n.ThreadID)},
 				{Key: atom.Title.String(), Val: "Mark as read"},
 			},
 			FirstChild: octiconssvg.Check(),

--- a/component/component.go
+++ b/component/component.go
@@ -49,6 +49,7 @@ func (a NotificationsByRepo) Render() []*html.Node {
 }
 
 func (a NotificationsByRepo) groupAndSort() []RepoNotifications {
+	// Group by RepoSpec into RepoNotifications collections.
 	rnm := make(map[notifications.RepoSpec]*RepoNotifications)
 	for _, n := range a.Notifications {
 		r := n.RepoSpec
@@ -69,6 +70,7 @@ func (a NotificationsByRepo) groupAndSort() []RepoNotifications {
 		}
 	}
 
+	// Sort by UpdatedAt time.
 	var rns []RepoNotifications
 	for _, rnp := range rnm {
 		sort.Sort(nByUpdatedAt(rnp.Notifications))

--- a/component/component.go
+++ b/component/component.go
@@ -50,7 +50,7 @@ func (a NotificationsByRepo) Render() []*html.Node {
 func (a NotificationsByRepo) groupAndSort() []RepoNotifications {
 	rnm := make(map[notifications.RepoSpec]*RepoNotifications)
 	for _, n := range a.Notifications {
-		var r notifications.RepoSpec = n.RepoSpec
+		r := n.RepoSpec
 		switch rnp := rnm[r]; rnp {
 		case nil: // First notification for this RepoSpec.
 			rn := RepoNotifications{
@@ -231,6 +231,7 @@ type Time struct {
 }
 
 func (t Time) Render() []*html.Node {
+	// TODO: Make this much nicer.
 	// <abbr title="{{.Format "Jan _2, 2006, 3:04 PM MST"}}">{{reltime .}}</abbr>
 	abbr := &html.Node{
 		Type: html.ElementNode, Data: atom.Abbr.String(),

--- a/component/component.go
+++ b/component/component.go
@@ -1,0 +1,24 @@
+package component
+
+import (
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/shurcooL/htmlg"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+type Time struct {
+	Time time.Time
+}
+
+func (t Time) Render() []*html.Node {
+	// <abbr title="{{.Format "Jan _2, 2006, 3:04 PM MST"}}">{{reltime .}}</abbr>
+	abbr := &html.Node{
+		Type: html.ElementNode, Data: atom.Abbr.String(),
+		Attr:       []html.Attribute{{Key: atom.Title.String(), Val: t.Time.Format("Jan _2, 2006, 3:04 PM MST")}},
+		FirstChild: htmlg.Text(humanize.Time(t.Time)),
+	}
+	return []*html.Node{abbr}
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/shurcooL/httpgzip"
 	"github.com/shurcooL/notifications"
 	"github.com/shurcooL/notificationsapp/assets"
+	"github.com/shurcooL/notificationsapp/component"
 	"github.com/shurcooL/users"
 )
 
@@ -160,6 +161,10 @@ type state struct {
 // notification for display purposes.
 type notification struct {
 	notifications.Notification
+}
+
+func (n notification) UpdatedAtComponent() htmlg.Component {
+	return component.Time{n.UpdatedAt}
 }
 
 // notificationsByUpdatedAt implements sort.Interface.


### PR DESCRIPTION
This is a huge refactor that largely replaces the use of HTML templates for rendering with pure Go components that emit HTML nodes.

The Go components are much easier to maintain, refactor, reuse, improve, test, and generate minified HTML (see [before](https://cloud.githubusercontent.com/assets/1924134/22623639/9a446cd4-eb2f-11e6-9340-75a9d082d2be.png) and [after](https://cloud.githubusercontent.com/assets/1924134/22623642/a2c74908-eb2f-11e6-8e16-ac6327ab911b.png)).

Also improve the structure of data flow. First perform service operations, then render. That makes it easy to detect and propagate errors (e.g., permission error, which is useful to detect and redirect to login page). Previously, the templates were calling services, which could fail after some HTML is already written. Also, getting errors out from `ExecuteTemplate` is lossy.

In the end, this simplifies and cleans up the code significantly, and enables multiple enhancements that would not have been possible otherwise! 🎉

